### PR TITLE
Int overflow for samples

### DIFF
--- a/fastq-lib.cpp
+++ b/fastq-lib.cpp
@@ -89,7 +89,7 @@ int read_fq_sam(FILE *in, int rno, struct fq *fq, const char *name) {
     return 1;
 }
 
-int read_fq(FILE *in, int rno, struct fq *fq, const char *name) {
+int read_fq(FILE *in, long long int rno, struct fq *fq, const char *name) {
     read_line(in, fq->id);
     if (fq->id.s && (*fq->id.s == '>')) {
         fq->id.s[0] = '@';

--- a/fastq-lib.h
+++ b/fastq-lib.h
@@ -83,7 +83,7 @@ const char *fext(const char *f);
 
 // read fq
 int read_line(FILE *in, struct line &l);                // 0=done, 1=ok, -1=err+continue
-int read_fq(FILE *in, int rno, struct fq *fq, const char *name=NULL);          // 0=done, 1=ok, -1=err+continue
+int read_fq(FILE *in, long long int rno, struct fq *fq, const char *name=NULL);          // 0=done, 1=ok, -1=err+continue
 int read_fq_sam(FILE *in, int rno, struct fq *fq, const char *name=NULL);          // 0=done, 1=ok, -1=err+continue
 void free_fq(struct fq *fq);
 

--- a/fastq-multx.cpp
+++ b/fastq-multx.cpp
@@ -39,35 +39,35 @@ const char * VERSION = "1.4";
 
 // barcode
 struct bc {
-	line id;
-	line seq;
-	char *out[6];			// one output per input
-	FILE *fout[6];
-	bool gzout[6];
-	int cnt;			// count found
-	bool shifted;			// count found in 1-shifted position
-	char * dual;			// is this a dual-indexed barcode?  if so, this points to the second index.
-	int dual_n;			// length of dual
+    line id;
+    line seq;
+    char *out[6];                 // one output per input
+    FILE *fout[6];
+    bool gzout[6];
+    long long int cnt;            // count found
+    bool shifted;                 // count found in 1-shifted position
+    char * dual;                  // is this a dual-indexed barcode?  if so, this points to the second index.
+    int dual_n;                   // length of dual
 };
 
 // group of barcodes
 struct group {
-	char *id;
-	int tcnt;			// number of codes past thresh
-	int i;				// my index
+    char *id;
+    int tcnt;                     // number of codes past thresh
+    int i;                        // my index
 };
 
 // barcode group
 struct bcg {
-	struct bc b;			// barcode
-        line group;			// group (fluidigm, truseq, etc)
-        int bcnt[6];			// matched begin of file n
-        int ecnt[6];			// matched end of file n
-        int bscnt[6];			// matched begin of file n, shifted by 1
-        int escnt[6];			// matched end of file n, shifted by 1
-        int dbcnt[6];                   // dual matched begin of file n
-        int decnt[6];                   // dual matched end of file n
-	struct group *gptr;
+    struct bc b;                  // barcode
+    line group;                   // group (fluidigm, truseq, etc)
+    int bcnt[6];                  // matched begin of file n
+    int ecnt[6];                  // matched end of file n
+    int bscnt[6];                 // matched begin of file n, shifted by 1
+    int escnt[6];                 // matched end of file n, shifted by 1
+    int dbcnt[6];                 // dual matched begin of file n
+    int decnt[6];                 // dual matched end of file n
+    struct group *gptr;
 };
 
 struct group* getgroup(char *s);
@@ -76,8 +76,8 @@ void usage(FILE *f);
 static int debug=0;
 // it's times like this when i think a class might be handy, but nah, not worth it
 typedef struct bnode {
-	char *seq;
-	int cnt;
+    char *seq;
+    int cnt;
 } bnode;
 
 struct group grs[MAX_GROUP_NUM];
@@ -100,93 +100,93 @@ size_t ignore_st;
 
 
 int main (int argc, char **argv) {
-	char c;
-	bool trim = true;
-	int mismatch = 1;
-	int mismatchdual = -1;
-	int mismatchtotal = 1;
-        bool indepmm = false;
-	int distance = 2;
-	int poor_distance = 0;       // count of skipped reads on distance only
-	int quality = 0;
-	char end = '\0';
-	char dend = '\0';
-	bool dual = false;
-	char *in[6];
-	const char *out[6];
-	int f_n=0;
-	int f_oarg=0;
-	const char* guide=NULL;		// use an indexed-read
-	const char* list=NULL;		// use a barcode master list
-	char verify='\0';
-	bool noexec = false;
-	const char *group = NULL;
+    char c;
+    bool trim = true;
+    int mismatch = 1;
+    int mismatchdual = -1;
+    int mismatchtotal = 1;
+    bool indepmm = false;
+    int distance = 2;
+    int poor_distance = 0;           // count of skipped reads on distance only
+    int quality = 0;
+    char end = '\0';
+    char dend = '\0';
+    bool dual = false;
+    char *in[6];
+    const char *out[6];
+    int f_n=0;
+    int f_oarg=0;
+    const char* guide=NULL;          // use an indexed-read
+    const char* list=NULL;           // use a barcode master list
+    char verify='\0';
+    bool noexec = false;
+    const char *group = NULL;
     bool usefile1 = false;
     int phred = 33;
     double threshfactor = 1;
     int bcinheader = 0;
 
-	int i;
-	bool omode = false;
-	char *bfil = NULL;
-	while (	(c = getopt (argc, argv, "-DzxnHhbeov:m:M:B:g:L:l:G:q:d:t:")) != -1) {
-		switch (c) t:{
-		case '\1':
-                       	if (omode) {
-				if (f_oarg<5)
-					out[f_oarg++] = optarg;
-				else {
-					usage(stderr); return 1;
-				}
-			} else if (!bfil && !guide && !list)
-				bfil = optarg;
-			else if (f_n<5) {
-				in[f_n++] = optarg;
-			} else {
-				usage(stderr); return 1;
-			}
-			break;
+    int i;
+    bool omode = false;
+    char *bfil = NULL;
+    while ((c = getopt (argc, argv, "-DzxnHhbeov:m:M:B:g:L:l:G:q:d:t:")) != -1) {
+        switch (c) t:{
+        case '\1':
+            if (omode) {
+            if (f_oarg<5)
+                out[f_oarg++] = optarg;
+                else {
+                    usage(stderr); return 1;
+                }
+            } else if (!bfil && !guide && !list)
+                bfil = optarg;
+            else if (f_n<5) {
+                in[f_n++] = optarg;
+            } else {
+                usage(stderr); return 1;
+            }
+            break;
                 case 'o': omode=true; break;
                 case 'v':
-			if (strlen(optarg)>1) {
-				fprintf(stderr, "Option -v requires a single character argument");
-				exit(1);
-			}
-			verify = *optarg; break;
-		case 'b': end = 'b'; break;
-		case 'h': usage(stdout); exit(0); break;
-		case 'H': bcinheader = 1; usefile1=1; break;
-		case 'e': end = 'e'; break;
-		case 'G': group = optarg; break;
-		case 'g':
-			guide = optarg;
-			in[f_n++] = optarg;
-			out[f_oarg++] = "n/a";
-			break;
-		case 'l': list = optarg; usefile1=0; break;
-		case 'L': list = optarg; usefile1=1; break;
-		case 'B': bfil = optarg; list = NULL; break;
-		case 'x': trim = false; break;
-		case 'n': noexec = true; break;
-		case 't': threshfactor = atof(optarg); break;
-		case 'm': mismatch = atoi(optarg); break;
-		case 'M': mismatchdual = atoi(optarg); break;
-		case 'd': distance = atoi(optarg); break;
-		case 'q': quality = atoi(optarg); break;
-		case 'D': ++debug; break;
-		case '?':
-		     if (strchr("vmBglG", optopt))
-		       fprintf (stderr, "Option -%c requires an argument.\n", optopt);
-		     else if (isprint(optopt))
-		       fprintf (stderr, "Unknown option `-%c'.\n", optopt);
-		     else
-		       fprintf (stderr,
-				"Unknown option character `\\x%x'.\n",
-				optopt);
-		     usage(stderr);
-             	     return 1;
-		}
-	}
+            if (strlen(optarg)>1) {
+                fprintf(stderr, "Option -v requires a single character argument");
+                exit(1);
+            }
+            verify = *optarg; break;
+        case 'b': end = 'b'; break;
+        case 'h': usage(stdout); exit(0); break;
+        case 'H': bcinheader = 1; usefile1=1; break;
+        case 'e': end = 'e'; break;
+        case 'G': group = optarg; break;
+        case 'g':
+            guide = optarg;
+            in[f_n++] = optarg;
+            out[f_oarg++] = "n/a";
+            break;
+        case 'l': list = optarg; usefile1=0; break;
+        case 'L': list = optarg; usefile1=1; break;
+        case 'B': bfil = optarg; list = NULL; break;
+        case 'x': trim = false; break;
+        case 'n': noexec = true; break;
+        case 't': threshfactor = atof(optarg); break;
+        case 'm': mismatch = atoi(optarg); break;
+        case 'M': mismatchdual = atoi(optarg); break;
+        case 'd': distance = atoi(optarg); break;
+        case 'q': quality = atoi(optarg); break;
+        case 'D': ++debug; break;
+        case '?':
+             if (strchr("vmBglG", optopt))
+               fprintf (stderr, "Option -%c requires an argument.\n", optopt);
+             else if (isprint(optopt))
+               fprintf (stderr, "Unknown option `-%c'.\n", optopt);
+             else
+               fprintf (stderr,
+                "Unknown option character `\\x%x'.\n",
+                optopt);
+             usage(stderr);
+                      return 1;
+        }
+    }
 
         mismatchtotal = mismatch;
         if (mismatchdual >= 0) {
@@ -194,53 +194,53 @@ int main (int argc, char **argv) {
             indepmm = true;
         }
 
-	if (group && !list) {
-		fprintf(stderr, "Error: -G only works with -l\n");
-		return 1;
-	}
+    if (group && !list) {
+        fprintf(stderr, "Error: -G only works with -l\n");
+        return 1;
+    }
 
     if ((list && guide) || (list && bfil) || (guide && bfil)) {
             fprintf(stderr, "Error: Only one of -B -g or -l\n");
             return 1;
     }
 
-	if (f_n != f_oarg) {
-		fprintf(stderr, "Error: number of input files (%d) must match number of output files following '-o'.\n", f_n);
-		return 1;
-	}
+    if (f_n != f_oarg) {
+        fprintf(stderr, "Error: number of input files (%d) must match number of output files following '-o'.\n", f_n);
+        return 1;
+    }
 
-	if (argc < 3 || !f_n || (!bfil && !guide && !list)) {
-		usage(stderr);
-		return 1;
-	}
+    if (argc < 3 || !f_n || (!bfil && !guide && !list)) {
+        usage(stderr);
+        return 1;
+    }
 
     quality+=phred;
 
-	FILE *fin[6];
-	bool gzin[6]; meminit(gzin);
-	for (i = 0; i < f_n; ++i) {
-		fin[i]=gzopen(in[i],"r",&gzin[i]);
-	}
+    FILE *fin[6];
+    bool gzin[6]; meminit(gzin);
+    for (i = 0; i < f_n; ++i) {
+        fin[i]=gzopen(in[i],"r",&gzin[i]);
+    }
 
-	// set all to null, zero
-	meminit(bc);
+    // set all to null, zero
+    meminit(bc);
 
 
-	// 3 ways to get barcodes
-	if (list) {
-		// use a list of barcode groups... determine the best set, then use the determined set
-		struct bcg *bcg = (struct bcg *) malloc(sizeof(*bcg) * MAX_GROUP_NUM * MAX_BARCODE_NUM);
-		if (!bcg) {
-                        fprintf(stderr, "Out of memory\n");
-                        return 1;
-		}
-		memset(bcg, 0, sizeof(*bcg) * MAX_GROUP_NUM * MAX_BARCODE_NUM);
-		int bgcnt=0;
-		int b;
+    // 3 ways to get barcodes
+    if (list) {
+        // use a list of barcode groups... determine the best set, then use the determined set
+        struct bcg *bcg = (struct bcg *) malloc(sizeof(*bcg) * MAX_GROUP_NUM * MAX_BARCODE_NUM);
+        if (!bcg) {
+            fprintf(stderr, "Out of memory\n");
+            return 1;
+        }
+        memset(bcg, 0, sizeof(*bcg) * MAX_GROUP_NUM * MAX_BARCODE_NUM);
+        int bgcnt=0;
+        int b;
         FILE *lin = fopen(list, "r");
         if (!lin) {
-                fprintf(stderr, "Error opening file '%s': %s\n",list, strerror(errno));
-                return 1;
+            fprintf(stderr, "Error opening file '%s': %s\n",list, strerror(errno));
+            return 1;
         }
         // read barcode groups
         int ok;
@@ -251,29 +251,29 @@ int main (int argc, char **argv) {
             bcg[bgcnt].b.id.s=strtok(bcg[bgcnt].b.id.s, "\t\n\r ");
             bcg[bgcnt].b.seq.s=strtok(NULL, "\t\n\r ");
             char *g=strtok(NULL, "\n\r");
-			if (!g) {
-				if (bgcnt==0){
-					fprintf(stderr,"Barcode guide list needs to be ID<whitespace>SEQUENCE<whitespace>GROUP");
-					return 1;
-				} else {
-					continue;
-				}
-			}
-			if (group) {
-				if (strcasecmp(group, g)) {
-					continue;
-				}
-			}
+            if (!g) {
+                if (bgcnt==0){
+                    fprintf(stderr,"Barcode guide list needs to be ID<whitespace>SEQUENCE<whitespace>GROUP");
+                    return 1;
+                } else {
+                    continue;
+                }
+            }
+            if (group) {
+                if (strcasecmp(group, g)) {
+                    continue;
+                }
+            }
             if (!strcmp(bcg[bgcnt].b.seq.s,"seq")) continue;
 
             // dual indexed indicated by a dash in the sequence...
-			if (bcg[bgcnt].b.dual=strchr(bcg[bgcnt].b.seq.s,'-')) {
-				*bcg[bgcnt].b.dual = '\0';
-				++bcg[bgcnt].b.dual;
-				bcg[bgcnt].b.dual_n = strlen(bcg[bgcnt].b.dual);
-			}
+            if (bcg[bgcnt].b.dual=strchr(bcg[bgcnt].b.seq.s,'-')) {
+                *bcg[bgcnt].b.dual = '\0';
+                ++bcg[bgcnt].b.dual;
+                bcg[bgcnt].b.dual_n = strlen(bcg[bgcnt].b.dual);
+            }
             // group pointer for this group
-			bcg[bgcnt].gptr = getgroup(g);
+            bcg[bgcnt].gptr = getgroup(g);
             bcg[bgcnt].b.id.n=strlen(bcg[bgcnt].b.id.s);
             bcg[bgcnt].b.seq.n=strlen(bcg[bgcnt].b.seq.s);
 
@@ -281,32 +281,32 @@ int main (int argc, char **argv) {
             ++bgcnt;
         }
 
-		if (!bgcnt) {
-			fprintf(stderr,"No barcodes %s from guide list %s.\n", group ? "matched" : "read", list);
-			return 1;
-		}
+        if (!bgcnt) {
+            fprintf(stderr,"No barcodes %s from guide list %s.\n", group ? "matched" : "read", list);
+            return 1;
+        }
 
         int sampcnt = 200000;
         struct stat st;
-		int fsum[f_n], fmax[f_n]; int bestcnt=0, besti=-1, bestdual=0;
-		int dfsum[f_n], dfmax[f_n]; int dbestcnt=0, dbesti=-1;
-		meminit(fsum); meminit(fmax); meminit(dfsum); meminit(dfmax);
+        int fsum[f_n], fmax[f_n]; int bestcnt=0, besti=-1, bestdual=0;
+        int dfsum[f_n], dfmax[f_n]; int dbestcnt=0, dbesti=-1;
+        meminit(fsum); meminit(fmax); meminit(dfsum); meminit(dfmax);
 
         // subsample to determine group to use
-		for (i=0;i<(usefile1?1:f_n);++i) {
+        for (i=0;i<(usefile1?1:f_n);++i) {
             char *s = NULL; size_t na = 0; int nr = 0, ns = 0;
             char *q = NULL; size_t nq = 0;
-			double tots=0, totsq=0;
-		    char *s2 = NULL; int ns2=0;
+            double tots=0, totsq=0;
+            char *s2 = NULL; int ns2=0;
             char *ignore_s=NULL;
 
-			stat(in[i], &st);
+            stat(in[i], &st);
 
-			while ((ns=getline(&s, &na, fin[i])) > 0) {
-				if (*s != '@')  {
-					fprintf(stderr,"Invalid fastq file: %s.\n", in[i]);
-					exit(1);
-				}
+            while ((ns=getline(&s, &na, fin[i])) > 0) {
+                if (*s != '@')  {
+                    fprintf(stderr,"Invalid fastq file: %s.\n", in[i]);
+                    exit(1);
+                }
 
                 if (bcinheader) {
                     // read in 3 more lines (seq, comment, qual) and ignore them
@@ -315,7 +315,7 @@ int main (int argc, char **argv) {
                     ignore=getline(&ignore_s, &ignore_st, fin[i]);
                     getbcfromheader(s, &ns, &q, &s2, &ns2);
                     nq=ns;
-               }  else {
+                }  else {
                     // read in 3 more lines (seq, comment, qual)
                     if ((ns=getline(&s, &na, fin[i])) <=0)
                         break;
@@ -323,239 +323,239 @@ int main (int argc, char **argv) {
                     ignore=getline(&q, &ignore_st, fin[i]);
                     nq=getline(&q, &ignore_st, fin[i]);
 
-    				s[--ns]='\0'; q[--nq]='\0';
+                    s[--ns]='\0'; q[--nq]='\0';
                 }
 
-// skip if quality is below average
-				if (st.st_size > (sampcnt * 500) && poorqual(i, ns, s, q))
-					continue;
+                // skip if quality is below average
+                if (st.st_size > (sampcnt * 500) && poorqual(i, ns, s, q))
+                    continue;
 
-				for (b=0;b<bgcnt;++b) {
+                for (b=0;b<bgcnt;++b) {
                     // matches front of read?
-					if (!strncasecmp(s, bcg[b].b.seq.s, bcg[b].b.seq.n)) {
-						++bcg[b].bcnt[i];
-					} else if (!strncasecmp(s+1, bcg[b].b.seq.s, bcg[b].b.seq.n)) {
+                    if (!strncasecmp(s, bcg[b].b.seq.s, bcg[b].b.seq.n)) {
+                        ++bcg[b].bcnt[i];
+                    } else if (!strncasecmp(s+1, bcg[b].b.seq.s, bcg[b].b.seq.n)) {
                         // shifted read?
-						++bcg[b].bscnt[i];
+                        ++bcg[b].bscnt[i];
                     }
 
-					if (ns >= bcg[b].b.seq.n && !strcasecmp(s+ns-bcg[b].b.seq.n, bcg[b].b.seq.s)) {
-						++bcg[b].ecnt[i];
-					} else if (ns > bcg[b].b.seq.n && !strncasecmp(s+ns-bcg[b].b.seq.n-1, bcg[b].b.seq.s, bcg[b].b.seq.n)) {
-						++bcg[b].escnt[i];
-					}
+                    if (ns >= bcg[b].b.seq.n && !strcasecmp(s+ns-bcg[b].b.seq.n, bcg[b].b.seq.s)) {
+                        ++bcg[b].ecnt[i];
+                    } else if (ns > bcg[b].b.seq.n && !strncasecmp(s+ns-bcg[b].b.seq.n-1, bcg[b].b.seq.s, bcg[b].b.seq.n)) {
+                        ++bcg[b].escnt[i];
+                    }
 
-					if (bcg[b].b.dual) {
+                    if (bcg[b].b.dual) {
                         const char * t=s;
                         int nt=ns;
                         if (bcinheader) {             // barcode in header? use stuff after '+' sign
                             t=s2;
                             nt=ns2;
                         }
-						if (!strncasecmp(t, bcg[b].b.dual, bcg[b].b.dual_n)) {
-							++bcg[b].dbcnt[i];
+                        if (!strncasecmp(t, bcg[b].b.dual, bcg[b].b.dual_n)) {
+                            ++bcg[b].dbcnt[i];
                         }
-						if (ns >= bcg[b].b.dual_n && !strcasecmp(t+nt-bcg[b].b.dual_n, bcg[b].b.dual)) {
-							++bcg[b].decnt[i];
+                        if (ns >= bcg[b].b.dual_n && !strcasecmp(t+nt-bcg[b].b.dual_n, bcg[b].b.dual)) {
+                            ++bcg[b].decnt[i];
                         }
-					}
-				}
+                    }
+                }
 
-				++nr;
+                ++nr;
                 // got enough reads?
-				if (nr >= sampcnt)
+                if (nr >= sampcnt)
                     break;
-			}
+            }
 
-			for (b=0;b<bgcnt;++b) {
-				// highest count
-				int hcnt = (int) (max(bcg[b].bcnt[i],bcg[b].ecnt[i]) * log(bcg[b].b.seq.n));
-				fsum[i]+=hcnt;
-				if (hcnt > fmax[i])
-					fmax[i]=hcnt;
+            for (b=0;b<bgcnt;++b) {
+                // highest count
+                int hcnt = (int) (max(bcg[b].bcnt[i],bcg[b].ecnt[i]) * log(bcg[b].b.seq.n));
+                fsum[i]+=hcnt;
+                if (hcnt > fmax[i])
+                    fmax[i]=hcnt;
 
-				if (fsum[i] > bestcnt)  {
+                if (fsum[i] > bestcnt)  {
                     if (debug > 1)
                         fprintf(stderr,"file %d(%s), bcg: %s, file-sum: %d, bestsum: %d\n", i, in[i], bcg[b].gptr->id, fsum[i], bestcnt);
 
-					bestcnt=fsum[i];
-					besti=i;
-					bestdual=(bcg[b].b.dual!=NULL);
-				}
+                    bestcnt=fsum[i];
+                    besti=i;
+                    bestdual=(bcg[b].b.dual!=NULL);
+                }
 
                 if (debug > 1)
                     fprintf(stderr,"dual %d(%s), bcg: %s, file-sum: %d, bestsum: %d\n", i, in[i], bcg[b].gptr->id, dfsum[i], dbestcnt);
 
-				if (bcg[b].b.dual) {
-					// highest count
-					int dcnt = (int) (max(bcg[b].dbcnt[i],bcg[b].decnt[i]) * log(bcg[b].b.dual_n));
-					dfsum[i]+=dcnt;
-					if (dcnt > dfmax[i])
-						dfmax[i]=dcnt;
-					if (dfsum[i] > dbestcnt)  {
+                if (bcg[b].b.dual) {
+                    // highest count
+                    int dcnt = (int) (max(bcg[b].dbcnt[i],bcg[b].decnt[i]) * log(bcg[b].b.dual_n));
+                    dfsum[i]+=dcnt;
+                    if (dcnt > dfmax[i])
+                        dfmax[i]=dcnt;
+                    if (dfsum[i] > dbestcnt)  {
                         if (debug > 1)
                             fprintf(stderr,"dual %d(%s), bcg: %s, file-sum: %d, bestsum: %d\n", i, in[i], bcg[b].gptr->id, dfsum[i], dbestcnt);
-						dbestcnt=dfsum[i];
-						dbesti=i;
-					}
-				}
+                        dbestcnt=dfsum[i];
+                        dbesti=i;
+                    }
+                }
                         }
-			if (debug > 0) fprintf(stderr,"file-best %d sum:%d, max:%d\n", besti, fsum[besti], fmax[besti]);
-			if (debug > 0 && bestdual) fprintf(stderr,"dual file-best %d sum:%d, max:%d\n", dbesti, dfsum[dbesti], dfmax[dbesti]);
-		}
+            if (debug > 0) fprintf(stderr,"file-best %d sum:%d, max:%d\n", besti, fsum[besti], fmax[besti]);
+            if (debug > 0 && bestdual) fprintf(stderr,"dual file-best %d sum:%d, max:%d\n", dbesti, dfsum[dbesti], dfmax[dbesti]);
+        }
 
         // chosen file is "besti"
-		i=usefile1?0:besti;
+        i=usefile1?0:besti;
 
-		int gmax=0, gindex=-1, scnt = 0, ecnt=0, dscnt = 0, decnt = 0;
-		int thresh = (int) (pickmaxpct*fmax[i]);
+        int gmax=0, gindex=-1, scnt = 0, ecnt=0, dscnt = 0, decnt = 0;
+        int thresh = (int) (pickmaxpct*fmax[i]);
 
-		if (debug > 0) fprintf(stderr,"besti: %d thresh: %d, dual: %d\n", besti, thresh, bestdual);
-		for (b=0;b<bgcnt;++b) {
-			int hcnt = (int) (max(bcg[b].bcnt[i],bcg[b].ecnt[i]) * log(bcg[b].b.seq.n));
-			if (debug > 1) fprintf(stderr,"cnt: %s %s hc:%d bc:%d ec: %d\n", bcg[b].b.id.s, bcg[b].b.seq.s, hcnt, bcg[b].bcnt[i], bcg[b].ecnt[i]);
-			if (hcnt >= thresh) {
-				// increase group count
-				bcg[b].gptr->tcnt += hcnt;
-				if (bcg[b].gptr->tcnt > gmax) {
-					gindex=bcg[b].gptr->i;
-					gmax=bcg[b].gptr->tcnt;
-				}
-			}
-		}
-		if (gindex == -1) {
+        if (debug > 0) fprintf(stderr,"besti: %d thresh: %d, dual: %d\n", besti, thresh, bestdual);
+        for (b=0;b<bgcnt;++b) {
+            int hcnt = (int) (max(bcg[b].bcnt[i],bcg[b].ecnt[i]) * log(bcg[b].b.seq.n));
+            if (debug > 1) fprintf(stderr,"cnt: %s %s hc:%d bc:%d ec: %d\n", bcg[b].b.id.s, bcg[b].b.seq.s, hcnt, bcg[b].bcnt[i], bcg[b].ecnt[i]);
+            if (hcnt >= thresh) {
+                // increase group count
+                bcg[b].gptr->tcnt += hcnt;
+                if (bcg[b].gptr->tcnt > gmax) {
+                    gindex=bcg[b].gptr->i;
+                    gmax=bcg[b].gptr->tcnt;
+                }
+            }
+        }
+        if (gindex == -1) {
             fprintf(stderr, "Unable to determine barcode group\n");
-			exit(1);
-		}
-//		printf("gmax: %d, gindex %d, %s, thresh: %d\n", gmax, gindex, grs[gindex].id, thresh);
+            exit(1);
+        }
+        //printf("gmax: %d, gindex %d, %s, thresh: %d\n", gmax, gindex, grs[gindex].id, thresh);
 
         for (b=0;b<bgcnt;++b) {
-			if (bcg[b].gptr->i == gindex) {
-				if (bcg[b].bcnt[i] > bcg[b].ecnt[i]) {
-					scnt+=bcg[b].dbcnt[i];
-				} else if (bcg[b].bcnt[i] < bcg[b].ecnt[i]) {
-					ecnt+=bcg[b].decnt[i];
-				}
-				if (bcg[b].dbcnt[dbesti] > bcg[b].decnt[dbesti]) {
-					dscnt+=bcg[b].dbcnt[dbesti];
-				} else if (bcg[b].dbcnt[dbesti] < bcg[b].decnt[dbesti]) {
-					decnt+=bcg[b].decnt[dbesti];
-				}
-			}
-		};
-		end = scnt >= ecnt ? 'b' : 'e';
+            if (bcg[b].gptr->i == gindex) {
+                if (bcg[b].bcnt[i] > bcg[b].ecnt[i]) {
+                    scnt+=bcg[b].dbcnt[i];
+                } else if (bcg[b].bcnt[i] < bcg[b].ecnt[i]) {
+                    ecnt+=bcg[b].decnt[i];
+                }
+                if (bcg[b].dbcnt[dbesti] > bcg[b].decnt[dbesti]) {
+                    dscnt+=bcg[b].dbcnt[dbesti];
+                } else if (bcg[b].dbcnt[dbesti] < bcg[b].decnt[dbesti]) {
+                    decnt+=bcg[b].decnt[dbesti];
+                }
+            }
+        };
+        end = scnt >= ecnt ? 'b' : 'e';
 
-		if (debug) fprintf(stderr,"scnt: %d, ecnt, %d, end: %c\n", scnt, ecnt, end);
+        if (debug) fprintf(stderr,"scnt: %d, ecnt, %d, end: %c\n", scnt, ecnt, end);
 
-		thresh/=threshfactor;
-		if (bestdual)
-		    thresh/=5;
+        thresh/=threshfactor;
+        if (bestdual)
+            thresh/=5;
 
-		// since this is a known good set, use a very low threshold, just to catch them all
+        // since this is a known good set, use a very low threshold, just to catch them all
         fprintf(stderr, "Using Barcode Group: %s on File: %s (%s), Threshold %2.2f%%\n",
         grs[gindex].id, in[i], endstr(end), 100.0 * (float) ((float)thresh/THFIXFACTOR)/sampcnt);
 
-		if (bestdual) {
-			dend = dscnt >= decnt ? 'b' : 'e';
-			fprintf(stderr, "Dual index on File: %s (%s)\n", in[dbesti], endstr(dend));
-			dual=true;
-			for (b=0;b<bgcnt;++b) {
-				// trim down a bit, but later should trim down to "both-match"
-				if (bcg[b].gptr->i == gindex) {
-					if (bcg[b].decnt[dbesti] < bcg[b].ecnt[i])
-						bcg[b].ecnt[i] = bcg[b].decnt[dbesti];
-					if (bcg[b].dbcnt[dbesti] < bcg[b].bcnt[i])
-						bcg[b].bcnt[i] = bcg[b].dbcnt[dbesti];
-				}
-			}
-		}
+        if (bestdual) {
+            dend = dscnt >= decnt ? 'b' : 'e';
+            fprintf(stderr, "Dual index on File: %s (%s)\n", in[dbesti], endstr(dend));
+            dual=true;
+            for (b=0;b<bgcnt;++b) {
+                // trim down a bit, but later should trim down to "both-match"
+                if (bcg[b].gptr->i == gindex) {
+                    if (bcg[b].decnt[dbesti] < bcg[b].ecnt[i])
+                        bcg[b].ecnt[i] = bcg[b].decnt[dbesti];
+                    if (bcg[b].dbcnt[dbesti] < bcg[b].bcnt[i])
+                        bcg[b].bcnt[i] = bcg[b].dbcnt[dbesti];
+                }
+            }
+        }
 
         for (b=0;b<bgcnt;++b) {
-			if (bcg[b].gptr->i == gindex) {
-				int cnt = (end == 'e' ? (bcg[b].ecnt[i]+bcg[b].escnt[i]) : ( bcg[b].bcnt[i] + bcg[b].bscnt[i] ));
-				if (cnt > thresh/THFIXFACTOR) {
-					// count exceeds threshold... use it
-					bc[bcnt]=bcg[b].b;
-					if ((end == 'e' && (bcg[b].escnt[i] < 1.2*bcg[b].ecnt[i])) ||
-					    (end == 'b' && (bcg[b].bscnt[i] < 1.2*bcg[b].bcnt[i]))
-					  ) {
-						if (!dual)
-							fprintf(stderr, "Using Barcode %s (%s)\n", bcg[b].b.id.s, bcg[b].b.seq.s);
+            if (bcg[b].gptr->i == gindex) {
+                int cnt = (end == 'e' ? (bcg[b].ecnt[i]+bcg[b].escnt[i]) : ( bcg[b].bcnt[i] + bcg[b].bscnt[i] ));
+                if (cnt > thresh/THFIXFACTOR) {
+                    // count exceeds threshold... use it
+                    bc[bcnt]=bcg[b].b;
+                    if ((end == 'e' && (bcg[b].escnt[i] < 1.2*bcg[b].ecnt[i])) ||
+                        (end == 'b' && (bcg[b].bscnt[i] < 1.2*bcg[b].bcnt[i]))
+                      ) {
+                        if (!dual)
+                            fprintf(stderr, "Using Barcode %s (%s)\n", bcg[b].b.id.s, bcg[b].b.seq.s);
 
-						if (debug) fprintf(stderr, "Debug Barcode %s (%s-%s) ... ecnt:%d, escnt:%d,bcnt:%d, bscnt:%d\n", bcg[b].b.id.s, bcg[b].b.seq.s, bcg[b].b.dual, bcg[b].ecnt[i], bcg[b].escnt[i], bcg[b].bcnt[i], bcg[b].bscnt[i]);
+                        if (debug) fprintf(stderr, "Debug Barcode %s (%s-%s) ... ecnt:%d, escnt:%d,bcnt:%d, bscnt:%d\n", bcg[b].b.id.s, bcg[b].b.seq.s, bcg[b].b.dual, bcg[b].ecnt[i], bcg[b].escnt[i], bcg[b].bcnt[i], bcg[b].bscnt[i]);
 
-					} else {
-						bc[bcnt].shifted=1;
+                    } else {
+                        bc[bcnt].shifted=1;
 
-						if (!dual)
-							fprintf(stderr, "Using Barcode %s (%s) shifted\n", bcg[b].b.id.s, bcg[b].b.seq.s);
+                        if (!dual)
+                            fprintf(stderr, "Using Barcode %s (%s) shifted\n", bcg[b].b.id.s, bcg[b].b.seq.s);
 
-						if (debug) printf("Debug Barcode %s (%s-%s) shifted ... ecnt:%d, escnt:%d,bcnt:%d, bscnt:%d\n", bcg[b].b.id.s, bcg[b].b.seq.s, bcg[b].b.dual, bcg[b].ecnt[i], bcg[b].escnt[i], bcg[b].bcnt[i], bcg[b].bscnt[i]);
-					}
-					++bcnt;
-				}
-			}
-		}
+                        if (debug) printf("Debug Barcode %s (%s-%s) shifted ... ecnt:%d, escnt:%d,bcnt:%d, bscnt:%d\n", bcg[b].b.id.s, bcg[b].b.seq.s, bcg[b].b.dual, bcg[b].ecnt[i], bcg[b].escnt[i], bcg[b].bcnt[i], bcg[b].bscnt[i]);
+                    }
+                    ++bcnt;
+                }
+            }
+        }
 
-		if (i != 0) {
-			// in[0] needs to be the guide file
-			FILE *f = fin[0];
-			char *n = in[0];
-			const char *o = out[0];
-			bool gzi = gzin[0];
-			fin[0]=fin[i];
-			in[0]=in[i];
-			out[0]=out[i];
-			gzin[0]=gzin[i];
-			fin[i]=f;
-			in[i]=n;
-			out[i]=o;
-			gzin[i]=gzi;
-			// swap file in to position 1 if dual
-			if (dual && dbesti != 1) {
-				FILE *f = fin[1];
-				char *n = in[1];
-				const char *o = out[1];
-				bool gzi = gzin[1];
-				fin[1]=fin[dbesti];
-				in[1]=in[dbesti];
-				out[1]=out[dbesti];
-				gzin[1]=gzin[dbesti];
-				fin[dbesti]=f;
-				in[dbesti]=n;
-				out[dbesti]=o;
-				gzin[dbesti]=gzi;
-			}
-		}
-		if (bcg) free(bcg);
-	} else if (guide) {
-		// use the first file as a "guide file" ... and select a set of codes from that
-		FILE *gin = fin[0];
+        if (i != 0) {
+            // in[0] needs to be the guide file
+            FILE *f = fin[0];
+            char *n = in[0];
+            const char *o = out[0];
+            bool gzi = gzin[0];
+            fin[0]=fin[i];
+            in[0]=in[i];
+            out[0]=out[i];
+            gzin[0]=gzin[i];
+            fin[i]=f;
+            in[i]=n;
+            out[i]=o;
+            gzin[i]=gzi;
+            // swap file in to position 1 if dual
+            if (dual && dbesti != 1) {
+                FILE *f = fin[1];
+                char *n = in[1];
+                const char *o = out[1];
+                bool gzi = gzin[1];
+                fin[1]=fin[dbesti];
+                in[1]=in[dbesti];
+                out[1]=out[dbesti];
+                gzin[1]=gzin[dbesti];
+                fin[dbesti]=f;
+                in[dbesti]=n;
+                out[dbesti]=o;
+                gzin[dbesti]=gzi;
+            }
+        }
+        if (bcg) free(bcg);
+    } else if (guide) {
+        // use the first file as a "guide file" ... and select a set of codes from that
+        FILE *gin = fin[0];
 
-		int blen = 0;
+        int blen = 0;
 
-		int sampcnt = 100000;
-		struct stat st;
-		stat(guide, &st);
+        int sampcnt = 100000;
+        struct stat st;
+        stat(guide, &st);
 
-		char *s = NULL; size_t na = 0; int nr = 0, ns = 0;
-		char *q = NULL; size_t nq = 0;
+        char *s = NULL; size_t na = 0; int nr = 0, ns = 0;
+        char *q = NULL; size_t nq = 0;
 
-// small sample to get lengths
-		double tots=0, totsq=0;
-		while ((ns=getline(&s, &na, gin)) > 0) {
-			if (*s != '@')  {
-				fprintf(stderr,"Invalid fastq file: %s.\n", in[0]);
-				exit(1);
-			}
+        // small sample to get lengths
+        double tots=0, totsq=0;
+        while ((ns=getline(&s, &na, gin)) > 0) {
+            if (*s != '@')  {
+                fprintf(stderr,"Invalid fastq file: %s.\n", in[0]);
+                exit(1);
+            }
 
             if (bcinheader) {
-                    ignore=getline(&q, &ignore_st, fin[i]);
-                    ignore=getline(&q, &ignore_st, fin[i]);
-                    ignore=getline(&q, &ignore_st, fin[i]);
-                    /// no dual barcode detection allowed
-                    getbcfromheader(s, &ns);
-                    printf("bc is %s\n", s);
+                ignore=getline(&q, &ignore_st, fin[i]);
+                ignore=getline(&q, &ignore_st, fin[i]);
+                ignore=getline(&q, &ignore_st, fin[i]);
+                /// no dual barcode detection allowed
+                getbcfromheader(s, &ns);
+                printf("bc is %s\n", s);
             } else {
                 if ((ns=getline(&s, &na, gin)) <=0)
                     break;
@@ -563,38 +563,38 @@ int main (int argc, char **argv) {
                 ignore=getline(&q, &ignore_st, gin);
             }
 
-			--ns;
-			tots+=ns;
-			totsq+=ns*ns;
-			++nr;
-			if (nr >= 200) break;
-		}
-		double dev = stdev(nr, tots, totsq);
+            --ns;
+            tots+=ns;
+            totsq+=ns*ns;
+            ++nr;
+            if (nr >= 200) break;
+        }
+        double dev = stdev(nr, tots, totsq);
 
-		// short, and nonvarying (by much, depends on the tech used)
-		if (dev < .25 && roundl(tots/nr) < 12) {
-			// most probably a barcode-only read
-			blen = (int) round(tots/nr);
-			end = 'b';
-		} else if (round(tots/nr) < 12) {
-			fprintf(stderr, "File %s looks to be barcode-only, but it's length deviation is too high (%.4g)\n", in[0], dev);
-			return 1;
-		} else {
-			fprintf(stderr, "File %s isn't a barcode-only file, try using -l instead\n", in[0]);
-			return 1;
-		}
+        // short, and nonvarying (by much, depends on the tech used)
+        if (dev < .25 && roundl(tots/nr) < 12) {
+            // most probably a barcode-only read
+            blen = (int) round(tots/nr);
+            end = 'b';
+        } else if (round(tots/nr) < 12) {
+            fprintf(stderr, "File %s looks to be barcode-only, but it's length deviation is too high (%.4g)\n", in[0], dev);
+            return 1;
+        } else {
+            fprintf(stderr, "File %s isn't a barcode-only file, try using -l instead\n", in[0]);
+            return 1;
+        }
 
-		fprintf(stderr, "Barcode length used: %d (%s)\n", blen, endstr(end));
+        fprintf(stderr, "Barcode length used: %d (%s)\n", blen, endstr(end));
 
-		// load a table of possble codes
-		pickmax=0;
-		picktab=NULL;
-		bnode * ent = NULL;
+        // load a table of possble codes
+        pickmax=0;
+        picktab=NULL;
+        bnode * ent = NULL;
         while ((ns=getline(&s, &na, gin)) > 0) {
-			if (*s != '@')  {
-				fprintf(stderr,"Invalid fastq file: %s.\n", in[i]);
-				exit(1);
-			}
+            if (*s != '@')  {
+                fprintf(stderr,"Invalid fastq file: %s.\n", in[i]);
+                exit(1);
+            }
 
             if (bcinheader) {
                 ignore=getline(&q, &ignore_st, fin[i]);
@@ -609,94 +609,94 @@ int main (int argc, char **argv) {
                 ignore=getline(&q, &ignore_st, gin);
                 if (getline(&q, &ignore_st, gin) != ns)
                     break;
-			    s[--ns]='\0'; q[ns]='\0';
+                s[--ns]='\0'; q[ns]='\0';
             }
 
-			if (st.st_size > (sampcnt * 500) && poorqual(i, ns, s, q))
-				continue;
+            if (st.st_size > (sampcnt * 500) && poorqual(i, ns, s, q))
+                continue;
 
             ++nr;
 
-			char *p;
-			if (end == 'b') {
-				p=s;
-			} else {
-				p=s+nr-blen;
-			}
-			p[blen]='\0';
-			if (!ent) {		// make a new ent
-				ent = (bnode *) malloc(sizeof(*ent));
-			    ent->seq=(char*)malloc(blen+1);;
+            char *p;
+            if (end == 'b') {
+                p=s;
+            } else {
+                p=s+nr-blen;
+            }
+            p[blen]='\0';
+            if (!ent) {        // make a new ent
+                ent = (bnode *) malloc(sizeof(*ent));
+                ent->seq=(char*)malloc(blen+1);;
             }
 
-			if (strchr(p, 'N')||strchr(p, 'n'))
-				continue;
+            if (strchr(p, 'N')||strchr(p, 'n'))
+                continue;
 
-			ent->cnt=0;
-			strcpy(ent->seq, p);
+            ent->cnt=0;
+            strcpy(ent->seq, p);
 
-			bnode *fent = * (bnode**)  tsearch(ent, &picktab, bnodecomp);
+            bnode *fent = * (bnode**)  tsearch(ent, &picktab, bnodecomp);
 
-			if (fent == ent)	// used the ent, added to tree
-				ent = NULL;	// need a new one
+            if (fent == ent)    // used the ent, added to tree
+                ent = NULL;    // need a new one
 
-			++fent->cnt;
+            ++fent->cnt;
 
-			if (fent->cnt > pickmax)
+            if (fent->cnt > pickmax)
                 pickmax=fent->cnt;
-			else if (fent->cnt > pickmax2)
+            else if (fent->cnt > pickmax2)
                 pickmax2=fent->cnt;
 
-			if (nr > sampcnt)
-				break;
-		}
-		pickmax=max(1,(int)(pickmaxpct*pickmax2));
-		fprintf(stderr, "Threshold used: %d\n", pickmax);
-		twalk(picktab, pickbest);
-	} else {
-		// user specifies a list of barcodes, indexed read is f[0] and f[1] if dual
-		FILE *bin = fopen(bfil, "r");
-		if (!bin) {
-			fprintf(stderr, "Error opening file '%s': %s\n",bfil, strerror(errno));
-			return 1;
-		}
+            if (nr > sampcnt)
+                break;
+        }
+        pickmax=max(1,(int)(pickmaxpct*pickmax2));
+        fprintf(stderr, "Threshold used: %d\n", pickmax);
+        twalk(picktab, pickbest);
+    } else {
+        // user specifies a list of barcodes, indexed read is f[0] and f[1] if dual
+        FILE *bin = fopen(bfil, "r");
+        if (!bin) {
+            fprintf(stderr, "Error opening file '%s': %s\n",bfil, strerror(errno));
+            return 1;
+        }
 
-		bcnt = 0;
-		int ok;
-		while (bcnt < MAX_BARCODE_NUM && (ok = read_line(bin, bc[bcnt].id))) {
-			if (ok <= 0) break;
-			if (bc[bcnt].id.s[0]=='#') continue;
-			bc[bcnt].id.s=strtok(bc[bcnt].id.s, "\t\n\r ");
-			bc[bcnt].seq.s=strtok(NULL, "\t\n\r ");
-			if (!bc[bcnt].seq.s) {
-				fprintf(stderr, "Barcode file '%s' required format is 'ID SEQ'\n",bfil);
-				return 1;
-			}
+        bcnt = 0;
+        int ok;
+        while (bcnt < MAX_BARCODE_NUM && (ok = read_line(bin, bc[bcnt].id))) {
+            if (ok <= 0) break;
+            if (bc[bcnt].id.s[0]=='#') continue;
+            bc[bcnt].id.s=strtok(bc[bcnt].id.s, "\t\n\r ");
+            bc[bcnt].seq.s=strtok(NULL, "\t\n\r ");
+            if (!bc[bcnt].seq.s) {
+                fprintf(stderr, "Barcode file '%s' required format is 'ID SEQ'\n",bfil);
+                return 1;
+            }
             if (bc[bcnt].dual=strchr(bc[bcnt].seq.s,'-')) {
                 *bc[bcnt].dual = '\0';
                 ++bc[bcnt].dual;
-				bc[bcnt].dual_n = strlen(bc[bcnt].dual);
-				dual=true;
+                bc[bcnt].dual_n = strlen(bc[bcnt].dual);
+                dual=true;
             }
-			bc[bcnt].id.n=strlen(bc[bcnt].id.s);
-			bc[bcnt].seq.n=strlen(bc[bcnt].seq.s);
-			if (debug) fprintf(stderr, "BC: %d bc:%s n:%d\n", bcnt, bc[bcnt].seq.s, bc[bcnt].seq.n);
-			++bcnt;
-		}
+            bc[bcnt].id.n=strlen(bc[bcnt].id.s);
+            bc[bcnt].seq.n=strlen(bc[bcnt].seq.s);
+            if (debug) fprintf(stderr, "BC: %d bc:%s n:%d\n", bcnt, bc[bcnt].seq.s, bc[bcnt].seq.n);
+            ++bcnt;
+        }
 
         fprintf(stderr, "Using Barcode File: %s\n", bfil);
-	}
+    }
 
-	if (noexec) {
-		int b;
-        	for (b=0;b<bcnt;++b) {
-			fprintf(stdout, "%s %s\n", bc[b].id.s, bc[b].seq.s);
-		}
-		exit(0);
-	}
+    if (noexec) {
+        int b;
+            for (b=0;b<bcnt;++b) {
+            fprintf(stdout, "%s %s\n", bc[b].id.s, bc[b].seq.s);
+        }
+        exit(0);
+    }
 
-	// for whatever reason, the end is not supplied... easy enough to determine accurately
-	// or it's dual... which means we need to resample stuff
+    // for whatever reason, the end is not supplied... easy enough to determine accurately
+    // or it's dual... which means we need to resample stuff
     if (bcinheader && !end) {
         end = 'b';
     }
@@ -801,90 +801,85 @@ int main (int argc, char **argv) {
         }
     }
 
-	if (bcnt == 0) {
-		fprintf(stderr, "No barcodes defined, quitting.\n");
-		exit(1);
-	}
+    if (bcnt == 0) {
+        fprintf(stderr, "No barcodes defined, quitting.\n");
+        exit(1);
+    }
 
-	// one beyond barcode count is unmatched
-	bc[bcnt].id.s=(char *)"unmatched";
+    // one beyond barcode count is unmatched
+    bc[bcnt].id.s=(char *)"unmatched";
 
-	// TODO: output barcode read ...but only for unmatched?
-	int b;
+    // TODO: output barcode read ...but only for unmatched?
+    int b;
     for (b=0;b<=bcnt;++b) {
-		for (i=0;i<f_n;++i) {
-			if (!strcasecmp(out[i],"n/a") || !strcasecmp(out[i],"/dev/null")) {
-				bc[b].out[i] = NULL;
-				bc[b].fout[i] = NULL;
-				continue;
-			}
-			const char *p=strchr(out[i],'%');
-			if (!p) fail("Each output file name must contain a '%%' sign, which is replaced by the barcode id\n");
-			bc[b].out[i]=(char *) malloc(strlen(out[i])+strlen(bc[b].id.s)+100);
-			strncpy(bc[b].out[i], out[i], p-out[i]);
-			bc[b].out[i][p-out[i]]='\0';
-			strcat(bc[b].out[i], bc[b].id.s);
-			strcat(bc[b].out[i], p+1);
-			if (!(bc[b].fout[i]=gzopen(bc[b].out[i], "w", &bc[b].gzout[i]))) {
-				fprintf(stderr, "Error opening output file '%s': %s\n",bc[b].out[i], strerror(errno));
-				return 1;
-			}
-		}
-	}
+        for (i=0;i<f_n;++i) {
+            if (!strcasecmp(out[i],"n/a") || !strcasecmp(out[i],"/dev/null")) {
+                bc[b].out[i] = NULL;
+                bc[b].fout[i] = NULL;
+                continue;
+            }
+            const char *p=strchr(out[i],'%');
+            if (!p) fail("Each output file name must contain a '%%' sign, which is replaced by the barcode id\n");
+            bc[b].out[i]=(char *) malloc(strlen(out[i])+strlen(bc[b].id.s)+100);
+            strncpy(bc[b].out[i], out[i], p-out[i]);
+            bc[b].out[i][p-out[i]]='\0';
+            strcat(bc[b].out[i], bc[b].id.s);
+            strcat(bc[b].out[i], p+1);
+            if (!(bc[b].fout[i]=gzopen(bc[b].out[i], "w", &bc[b].gzout[i]))) {
+                fprintf(stderr, "Error opening output file '%s': %s\n",bc[b].out[i], strerror(errno));
+                return 1;
+            }
+        }
+    }
 
-	// seek back to beginning of fastq
-	for (i=0;i<f_n;++i) {
-		if (!gzin[i])
-			fseek(fin[i],0,0);
-		else {
-			pclose(fin[i]);
-			fin[i]=gzopen(in[i],"r",&gzin[i]);
-		}
-	}
+    // seek back to beginning of fastq
+    for (i=0;i<f_n;++i) {
+        if (!gzin[i])
+            fseek(fin[i],0,0);
+        else {
+            pclose(fin[i]);
+            fin[i]=gzopen(in[i],"r",&gzin[i]);
+        }
+    }
 
     // don't trim if you're not outputting the read
 
-	struct fq fq[8];
+    struct fq fq[8];
 
     meminit(fq);
 
-	int nrec=0;
-	int nerr=0;
-	int nok=0;
-	int ntooshort=0;
-	int ntrim=0;
-	int nbtrim=0;
-	int read_ok;
+    long long int nrec=0;
+    int read_ok;
 
     // ACTUAL DEMUX HAPPENS HERE
-	// read in 1 record from EACH file supplied
-	while (read_ok=read_fq(fin[0], nrec, &fq[0])) {
-		for (i=1;i<f_n;++i) {
-			int mate_ok=read_fq(fin[i], nrec, &fq[i]);
-			if (read_ok != mate_ok) {
-				fprintf(stderr, "# of rows in mate file '%s' doesn't match primary file, quitting!\n", in[i]);
-				return 1;
-			}
-			if (verify) {
-				// verify 1 in 100
-				if (0 == (nrec % 100)) {
-					char *p=strchr(fq[i].id.s,verify);
-					if (!p) {
-						fprintf(stderr, "File %s is missing id verification char %c at line %d", in[i], verify, nrec*4+1);
-						return 1;
-					}
-					int l = p-fq[i].id.s;
-					if (strncmp(fq[0].id.s, fq[i].id.s, l)) {
-						fprintf(stderr, "File %s, id doesn't match file %s at line %d", in[0], in[i], nrec*4+1);
-						return 1;
-					}
-				}
-			}
-		}
-		++nrec;
-		if (read_ok < 0) continue;
+    // read in 1 record from EACH file supplied
+    while (read_ok=read_fq(fin[0], nrec, &fq[0])) {
+        for (i=1;i<f_n;++i) {
+            int mate_ok=read_fq(fin[i], nrec, &fq[i]);
+            if (read_ok != mate_ok) {
+                fprintf(stderr, "# of rows in mate file '%s' doesn't match primary file, quitting!\n", in[i]);
+                return 1;
+            }
+            if (verify) {
+                // verify 1 in 100
+                if (0 == (nrec % 100)) {
+                    char *p=strchr(fq[i].id.s,verify);
+                    if (!p) {
+                        fprintf(stderr, "File %s is missing id verification char %c at line %lld", in[i], verify, nrec*4+1);
+                        return 1;
+                    }
+                    int l = p-fq[i].id.s;
+                    if (strncmp(fq[0].id.s, fq[i].id.s, l)) {
+                        fprintf(stderr, "File %s, id doesn't match file %s at line %lld", in[0], in[i], nrec*4+1);
+                        return 1;
+                    }
+                }
+            }
+        }
+        ++nrec;
+        if (read_ok < 0) continue;
 
-		int i, best=-1, bestmm=mismatchtotal+distance+1, bestd=mismatchtotal+distance+1, next_best=mismatchtotal+distance*2+1;
+        int i, best=-1, bestmm=mismatchtotal+distance+1, bestd=mismatchtotal+distance+1, next_best=mismatchtotal+distance*2+1;
 
         if (bcinheader) {
             for (i=f_n-1;i>=0;--i) {
@@ -899,13 +894,13 @@ int main (int argc, char **argv) {
             }
         }
 
-		if (debug) {
-			if (!bcinheader) fq[0].id.s[fq[0].id.n-1] = '\0';
-			fprintf(stderr, "id: %s, seq: %s %d", fq[0].id.s, fq[0].seq.s, fq[0].seq.n);
-			if (dual) fprintf(stderr, ", sdual: %s %d", fq[1].seq.s, fq[1].seq.n);
-			if (!bcinheader) fq[0].id.s[fq[0].id.n] = '\n';
-			if (debug > 1) printf("\n");
-		}
+        if (debug) {
+            if (!bcinheader) fq[0].id.s[fq[0].id.n-1] = '\0';
+            fprintf(stderr, "id: %s, seq: %s %d", fq[0].id.s, fq[0].seq.s, fq[0].seq.n);
+            if (dual) fprintf(stderr, ", sdual: %s %d", fq[1].seq.s, fq[1].seq.n);
+            if (!bcinheader) fq[0].id.s[fq[0].id.n] = '\n';
+            if (debug > 1) printf("\n");
+        }
 
         if (quality > 0) {
             // low quality base = 'N'
@@ -965,11 +960,11 @@ int main (int argc, char **argv) {
                         d+=hd(fq[1].seq.s,bc[i].dual, bc[i].dual_n);
                 }
 
-                //				if (debug > 1) {
-                //					fprintf(stderr, "index: %d dist: %d bc:%s n:%d", i, d, bc[i].seq.s, bc[i].seq.n);
-                //					if (dual) fprintf(stderr, ", idual: %s %d", bc[i].dual, bc[i].dual_n);
-                //					fprintf(stderr, "\n");
-                //				}
+                //if (debug > 1) {
+                //    fprintf(stderr, "index: %d dist: %d bc:%s n:%d", i, d, bc[i].seq.s, bc[i].seq.n);
+                //    if (dual) fprintf(stderr, ", idual: %s %d", bc[i].dual, bc[i].dual_n);
+                //    fprintf(stderr, "\n");
+                //}
             }
             // simple...
             if ((d + dd) < bestd) {
@@ -985,9 +980,9 @@ int main (int argc, char **argv) {
             } else if ((d+dd) <= mismatchtotal && (!indepmm || (d <= mismatch && dd <= mismatchdual))) {
                 // if ok match
                 if ((d+dd) == bestmm) {
-                    best=-1;		// more than 1 match... bad
+                    best=-1;        // more than 1 match... bad
                 } else if ((d+dd) < bestmm) {
-                    bestmm=d+dd;		// best match...ok
+                    bestmm=d+dd;        // best match...ok
                     best=i;
                 }
             }
@@ -1002,26 +997,26 @@ int main (int argc, char **argv) {
 
         bool trimmed = false;
         // only trim if you're outputting the sequence
-		if (trim && best >= 0 && bc[best].fout[0]) {
-			// todo: save trimmed
+        if (trim && best >= 0 && bc[best].fout[0]) {
+            // todo: save trimmed
             trimmed = true;
-			int len=bc[best].seq.n;
-			if (end =='b') {
-				memmove(fq[0].seq.s, fq[0].seq.s+len, fq[0].seq.n-len);
-				memmove(fq[0].qual.s, fq[0].qual.s+len, fq[0].seq.n-len);
-			}
-			fq[0].seq.s[fq[0].seq.n-len]='\0';
-			fq[0].qual.s[fq[0].qual.n-len]='\0';
-		}
+            int len=bc[best].seq.n;
+            if (end =='b') {
+                memmove(fq[0].seq.s, fq[0].seq.s+len, fq[0].seq.n-len);
+                memmove(fq[0].qual.s, fq[0].qual.s+len, fq[0].seq.n-len);
+            }
+            fq[0].seq.s[fq[0].seq.n-len]='\0';
+            fq[0].qual.s[fq[0].qual.n-len]='\0';
+        }
 
-		if (best < 0) {
+        if (best < 0) {
             // shuttle to unmatched file
-			best=bcnt;
-		}
+            best=bcnt;
+        }
 
-		if (debug) fprintf(stderr, ", best: %d %s\n", best, bc[best].id.s);
+        if (debug) fprintf(stderr, ", best: %d %s\n", best, bc[best].id.s);
 
-		++bc[best].cnt;
+        ++bc[best].cnt;
 
         int shift_index=0;
         if (bcinheader) {
@@ -1030,11 +1025,11 @@ int main (int argc, char **argv) {
                 shift_index = 2;
         }
 
-		for (i=shift_index;i<f_n+shift_index;++i) {
-			FILE *f=bc[best].fout[i-shift_index];
-			if (!f) continue;
+        for (i=shift_index;i<f_n+shift_index;++i) {
+            FILE *f=bc[best].fout[i-shift_index];
+            if (!f) continue;
             if (!trimmed) {
-			    // todo: capture always, not just when trim is off
+                // todo: capture always, not just when trim is off
                 *strrchr(fq[i].id.s, '\n') = '\0';
                 fputs(fq[i].id.s,f);
                 fputc(' ', f);
@@ -1053,8 +1048,8 @@ int main (int argc, char **argv) {
             fputs(fq[i].com.s,f);
             fputs(fq[i].qual.s,f);
             fputc('\n',f);
-		}
-	}
+        }
+    }
 
     bool io_ok=1;
     for (b=0;b<=bcnt;++b) {
@@ -1076,66 +1071,66 @@ int main (int argc, char **argv) {
     if (!io_ok)
         fprintf(stderr, "Returning error because of i/o error during file close\n");
 
-	int j;
-	printf("Id\tCount\tFile(s)\n");
-	long long int tot=0;
-	for (i=0;i<=bcnt;++i) {
-		printf("%s\t%d", bc[i].id.s, bc[i].cnt);
-		tot+=bc[i].cnt;
-		for (j=0;j<f_n;++j) {
-			if (bc[i].out[j])
-				printf("\t%s", bc[i].out[j]);
-		}
-		printf("\n");
-	}
-	printf("total\t%lld\n", tot);
+    int j;
+    printf("Id\tCount\tFile(s)\n");
+    long long int tot=0;
+    for (i=0;i<=bcnt;++i) {
+        printf("%s\t%lld", bc[i].id.s, bc[i].cnt);
+        tot+=bc[i].cnt;
+        for (j=0;j<f_n;++j) {
+            if (bc[i].out[j])
+                printf("\t%s", bc[i].out[j]);
+        }
+        printf("\n");
+    }
+    printf("total\t%lld\n", tot);
 
     if (!io_ok)
         return 3;
 
-	return 0;
+    return 0;
 }
 
 struct group* getgroup(char *s) {
-	int i;
-	for (i=0;i<grcnt;++i) {
-		if (!strcasecmp(s,grs[i].id)) {
-			return &grs[i];
-		}
-	}
+    int i;
+    for (i=0;i<grcnt;++i) {
+        if (!strcasecmp(s,grs[i].id)) {
+            return &grs[i];
+        }
+    }
     if (grcnt >= MAX_GROUP_NUM) {
         fprintf(stderr,"Too many barcode groups, quitting\n");
         exit(1);
     }
-	grs[grcnt].id=(char *)malloc(strlen(s)+1);
+    grs[grcnt].id=(char *)malloc(strlen(s)+1);
     strcpy(grs[grcnt].id,s);
-	grs[grcnt].tcnt=0;
-	grs[grcnt].i=grcnt;
-	return &grs[grcnt++];
+    grs[grcnt].tcnt=0;
+    grs[grcnt].i=grcnt;
+    return &grs[grcnt++];
 }
 
 void pickbest(const void *nodep, const VISIT which, const int depth)
 {
-	if (which==endorder || which==leaf) {
-		bnode *ent = *(bnode **) nodep;
-//		 printf("HERE!! %s, %d, %d\n", ent->seq, ent->cnt, pickmax);
-		// allow one sample to be as much as 1/10 another, possibly too conservative
-		if (ent->cnt > pickmax && bcnt < MAX_BARCODE_NUM) {
-			bc[bcnt].seq.s=ent->seq;
-			bc[bcnt].id.s=ent->seq;
-			bc[bcnt].id.n=strlen(bc[bcnt].id.s);
-			bc[bcnt].seq.n=strlen(bc[bcnt].seq.s);
-			++bcnt;
-		} else {
-			//free(ent->seq);
-		}
-		//free(ent);
-		//tdelete((void*)ent, &picktab, scompare);
-	}
+    if (which==endorder || which==leaf) {
+        bnode *ent = *(bnode **) nodep;
+         //printf("HERE!! %s, %d, %d\n", ent->seq, ent->cnt, pickmax);
+        // allow one sample to be as much as 1/10 another, possibly too conservative
+        if (ent->cnt > pickmax && bcnt < MAX_BARCODE_NUM) {
+            bc[bcnt].seq.s=ent->seq;
+            bc[bcnt].id.s=ent->seq;
+            bc[bcnt].id.n=strlen(bc[bcnt].id.s);
+            bc[bcnt].seq.n=strlen(bc[bcnt].seq.s);
+            ++bcnt;
+        } else {
+            //free(ent->seq);
+        }
+        //free(ent);
+        //tdelete((void*)ent, &picktab, scompare);
+    }
 }
 
 void usage(FILE *f) {
-	fprintf(f,
+    fprintf(f,
 "Usage: fastq-multx [-g|-l|-B] <barcodes.fil> <read1.fq> [mate.fq] -o r1.%%.fq [-o r2.%%.fq] ...\n"
 "Version: %s.%d\n"
 "\n"
@@ -1184,7 +1179,7 @@ void usage(FILE *f) {
 "-M M        Allow N,M mismatches in indexes 1,2 respectively (see -m N) (not used)\n"
 "-d N        Require a minimum distance of N between the best and next best (2)\n"
 "-q N        Require a minimum phred quality of N to accept a barcode base (0)\n"
-	,VERSION,SVNREV);
+    ,VERSION,SVNREV);
 }
 
 void getbcfromheader(struct fq *fq, struct fq *bc, char **s2, int *ns2) {
@@ -1202,7 +1197,7 @@ void getbcfromheader(struct fq *fq, struct fq *bc, char **s2, int *ns2) {
     getbcfromheader(bc->seq.s, &(bc->seq.n), &(bc->qual.s), s2, ns2);
     bc->qual.n=bc->seq.n;
 
-//printf("DEBUG: seq is %s, length is %d\n", bc->seq.s, bc->seq.n);
+    //printf("DEBUG: seq is %s, length is %d\n", bc->seq.s, bc->seq.n);
 }
 
 // looks for barcode in s, totally replaces s with barcode only, sets ns to length

--- a/fastq-multx.cpp
+++ b/fastq-multx.cpp
@@ -35,7 +35,7 @@ See "void usage" below for usage.
 #define endstr(e) (e=='e'?"end":e=='b'?"start":"n/a")
 
 const char * VERSION = "1.4";
-#define SVNREV 2
+#define SVNREV 3
 
 // barcode
 struct bc {


### PR DESCRIPTION
Sorry about all the white space differences.  (I changed the mixed tab/space indenting to just space.  -  I just learned you can hide white space changes using the gear menu thing and select to hide whitespaces differences.)

Anyway, the crux of the real difference here is I changed bc[x].cnt and nrec from `int` to `long long int`.

Oh, and also, I did test this on a huge dataset and it works.  I pasted the output in a comment of issue #18.

Resolves issue #18